### PR TITLE
Fixed case without a proper return value.

### DIFF
--- a/source/blender/editors/io/io_usd.c
+++ b/source/blender/editors/io/io_usd.c
@@ -137,6 +137,7 @@ static char *usd_ensure_prim_path(char *primpath)
     primpath = legal_path;
     return legal_path;
   }
+  return primpath;
 }
 
 static int wm_usd_export_exec(bContext *C, wmOperator *op)


### PR DESCRIPTION
usd_ensure_prim_path would end up setting valid strings to NULL since the function had no return value.