### PR TITLE
Bugfix: Treat Curve widths as diameters

### DIFF
--- a/source/blender/io/usd/intern/usd_writer_curve.cc
+++ b/source/blender/io/usd/intern/usd_writer_curve.cc
@@ -121,7 +121,7 @@ void USDCurveWriter::do_write(HierarchyContext &context)
       for (int i = 0; i < totpoint; i++, point++) {
         verts.push_back(pxr::GfVec3f(point->vec));
         weights.push_back(point->vec[3]);
-        widths.push_back(point->radius);
+        widths.push_back(point->radius * 2.0f);
       }
     }
     else if (nurbs->bezt) {
@@ -140,24 +140,24 @@ void USDCurveWriter::do_write(HierarchyContext &context)
 
         if (i > 0) {
           verts.push_back(pxr::GfVec3f(bezier->vec[0]));
-          widths.push_back(bezier->radius);
+          widths.push_back(bezier->radius * 2.0f);
         }
 
         verts.push_back(pxr::GfVec3f(bezier->vec[1]));
-        widths.push_back(bezier->radius);
+        widths.push_back(bezier->radius * 2.0f);
 
         if (i < totpoint - 1 || is_cyclic) {
           verts.push_back(pxr::GfVec3f(bezier->vec[2]));
-          widths.push_back(bezier->radius);
+          widths.push_back(bezier->radius * 2.0f);
         }
       }
 
       if (is_cyclic) {
         verts.push_back(pxr::GfVec3f(nurbs->bezt->vec[0]));
-        widths.push_back(nurbs->bezt->radius);
+        widths.push_back(nurbs->bezt->radius * 2.0f);
 
         verts.push_back(pxr::GfVec3f(nurbs->bezt->vec[1]));
-        widths.push_back(nurbs->bezt->radius);
+        widths.push_back(nurbs->bezt->radius * 2.0f);
       }
     }
     // TODO: Implement knots

--- a/source/blender/io/usd/intern/usd_writer_hair.cc
+++ b/source/blender/io/usd/intern/usd_writer_hair.cc
@@ -38,6 +38,7 @@ USDHairWriter::USDHairWriter(const USDExporterContext &ctx) : USDAbstractWriter(
 {
 }
 
+// This was copied from source/intern/cycles/blender/blender_curves.cpp
 static float shaperadius(float shape, float root, float tip, float time)
 {
   assert(time >= 0.0f);
@@ -109,7 +110,7 @@ void USDHairWriter::do_write(HierarchyContext &context)
       float t = (float)point_index / (float)(point_count - 1);
       // if(point_index == point_count - 1) t = 0.95f;
       float root_rad = (close_tip && point_index == point_count - 1) ? 0 : hair_tip_rad;
-      widths.push_back(shaperadius(hair_shape, hair_root_rad, root_rad, t));
+      widths.push_back(shaperadius(hair_shape, hair_root_rad, root_rad, t) * 2.0f);
     }
   }
 
@@ -129,7 +130,7 @@ void USDHairWriter::do_write(HierarchyContext &context)
           points.push_back(pxr::GfVec3f(vert));
           float t = (float)point_index / (float)(point_count - 1);
           t = clamp_f(t, 0.0f, 0.95f);
-          widths.push_back(shaperadius(hair_shape, hair_root_rad, hair_tip_rad, t));
+          widths.push_back(shaperadius(hair_shape, hair_root_rad, hair_tip_rad, t) * 2.0f);
         }
       }
     }


### PR DESCRIPTION
Change to author UsdGeomBasisCurve widths as diameter instead of radius.

This fix has already been pushed for HdCycles. This brings parity to the usd exporter.