### PR TITLE
Added a bound check for vertex deform groups on export

### DIFF
--- a/source/blender/io/usd/intern/usd_writer_mesh.cc
+++ b/source/blender/io/usd/intern/usd_writer_mesh.cc
@@ -345,7 +345,10 @@ void USDGenericMeshWriter::write_vertex_groups(const Object *ob,
         for (j = 0; j < vert->totweight; j++) {
           uint idx = vert->dw[j].def_nr;
           float w = vert->dw[j].weight;
-          pv_data[idx][i] = w;
+          if (idx < num_groups)
+          {
+            pv_data[idx][i] = w;
+          }
         }
       }
     }
@@ -369,7 +372,10 @@ void USDGenericMeshWriter::write_vertex_groups(const Object *ob,
           for (j = 0; j < vert->totweight; j++) {
             uint idx = vert->dw[j].def_nr;
             float w = vert->dw[j].weight;
-            pv_data[idx][p_idx] = w;
+            if (idx < num_groups)
+            {
+              pv_data[idx][i] = w;
+            }
           }
         }
         p_idx++;

--- a/source/blender/io/usd/intern/usd_writer_mesh.cc
+++ b/source/blender/io/usd/intern/usd_writer_mesh.cc
@@ -345,6 +345,9 @@ void USDGenericMeshWriter::write_vertex_groups(const Object *ob,
         for (j = 0; j < vert->totweight; j++) {
           uint idx = vert->dw[j].def_nr;
           float w = vert->dw[j].weight;
+          /* This out of bounds check is necessary because MDeformVert.totweight can be
+          larger than the number of bDeformGroup structs in Object.defbase. It appears to be
+          a Blender bug that can cause this scenario.*/ 
           if (idx < num_groups)
           {
             pv_data[idx][i] = w;
@@ -372,6 +375,9 @@ void USDGenericMeshWriter::write_vertex_groups(const Object *ob,
           for (j = 0; j < vert->totweight; j++) {
             uint idx = vert->dw[j].def_nr;
             float w = vert->dw[j].weight;
+            /* This out of bounds check is necessary because MDeformVert.totweight can be
+            larger than the number of bDeformGroup structs in Object.defbase. Appears to be
+            a Blender bug that can cause this scenario.*/ 
             if (idx < num_groups)
             {
               pv_data[idx][p_idx] = w;

--- a/source/blender/io/usd/intern/usd_writer_mesh.cc
+++ b/source/blender/io/usd/intern/usd_writer_mesh.cc
@@ -374,7 +374,7 @@ void USDGenericMeshWriter::write_vertex_groups(const Object *ob,
             float w = vert->dw[j].weight;
             if (idx < num_groups)
             {
-              pv_data[idx][i] = w;
+              pv_data[idx][p_idx] = w;
             }
           }
         }


### PR DESCRIPTION
This should solve the crash that happened when the MDeformWeight->def_nr was greater than the number of bDeformGroup structs associated with the object. I was unable to determine the scenario that created these conditions but this logic should be identical to how their internal code handles it (see BKE_defvert_find_index).