### PR TITLE
Bugfix: Changed gradient type to proper cycles naming

### DIFF
--- a/source/blender/io/usd/intern/usd_writer_material.cc
+++ b/source/blender/io/usd/intern/usd_writer_material.cc
@@ -572,7 +572,7 @@ pxr::UsdShadeShader create_cycles_shader_node(pxr::UsdStageRefPtr a_stage,
         break;
       // TexMapping tex_mapping;
       // ColorMapping color_mapping;
-      shader.CreateInput(pxr::TfToken("gradient_type"), pxr::SdfValueTypeNames->Int)
+      shader.CreateInput(pxr::TfToken("type"), pxr::SdfValueTypeNames->Int)
           .Set(grad_storage->gradient_type);
     } break;
 


### PR DESCRIPTION
The USDShade exporter was incorrectly naming the gradient texture "type" attribute as "gradient_type". This has been changed to "type".