### PR TITLE
Implement support for exporting animated textures to USD

### DIFF
--- a/source/blender/io/usd/CMakeLists.txt
+++ b/source/blender/io/usd/CMakeLists.txt
@@ -118,3 +118,5 @@ else()
 endif()
 
 target_link_libraries(bf_usd INTERFACE ${TBB_LIBRARIES})
+
+add_dependencies(bf_usd bf_rna)

--- a/source/blender/io/usd/intern/usd_capi.cc
+++ b/source/blender/io/usd/intern/usd_capi.cc
@@ -150,7 +150,9 @@ static void export_startjob(void *customdata, short *stop, short *do_update, flo
     pxr::UsdShadeMaterial world_mat = pxr::UsdShadeMaterial::Define(
         usd_stage, environment_light_path.AppendChild(pxr::TfToken("world_material")));
     create_usd_cycles_material(
-        usd_stage, scene->world->nodetree, world_mat, data->params.export_as_overs);
+        usd_stage, scene->world->nodetree, world_mat, data->params.export_as_overs,
+        data->params.export_animated_textures, data->params.anim_tex_start,
+        data->params.anim_tex_end, CFRA);
 
     // Convert node graph to USD Dome Light
 

--- a/source/blender/io/usd/intern/usd_util.cc
+++ b/source/blender/io/usd/intern/usd_util.cc
@@ -398,7 +398,7 @@ void ntree_shader_groups_flatten(bNodeTree *localtree)
 /* ===== USD/Blender Material Interchange ===== */
 
 /* Gets a NodeTexImage's filepath */
-std::string get_node_tex_image_filepath(bNode *node)
+std::string get_node_tex_image_filepath(bNode *node, const int frame_num)
 {
   NodeTexImage *tex_original = (NodeTexImage *)node->storage;
 
@@ -423,6 +423,13 @@ std::string get_node_tex_image_filepath(bNode *node)
 
     BLI_path_sequence_decode(filepath, head, tail, &numlen);
     sprintf(filepath, "%s%s%s", head, "<UDIM>", tail);
+  }
+  else if (ima->source == IMA_SRC_SEQUENCE && frame_num != INT_MIN) {
+    char head[FILE_MAX], tail[FILE_MAX];
+    unsigned short numlen;
+
+    BLI_path_sequence_decode(filepath, head, tail, &numlen);
+    sprintf(filepath, "%s%03d%s", head, frame_num, tail);
   }
 
   return std::string(filepath);

--- a/source/blender/io/usd/intern/usd_util.cc
+++ b/source/blender/io/usd/intern/usd_util.cc
@@ -429,7 +429,7 @@ std::string get_node_tex_image_filepath(bNode *node, const int frame_num)
     unsigned short numlen;
 
     BLI_path_sequence_decode(filepath, head, tail, &numlen);
-    sprintf(filepath, "%s%03d%s", head, frame_num, tail);
+    BLI_path_sequence_encode(filepath, head, tail, numlen, frame_num);
   }
 
   return std::string(filepath);

--- a/source/blender/io/usd/intern/usd_util.h
+++ b/source/blender/io/usd/intern/usd_util.h
@@ -58,7 +58,7 @@ void ntree_shader_groups_expand_inputs(bNodeTree *localtree);
 
 void ntree_shader_groups_flatten(bNodeTree *localtree);
 
-std::string get_node_tex_image_filepath(bNode *node);
+std::string get_node_tex_image_filepath(bNode *node, const int frame_num=INT_MIN);
 
 }  // Namespace USD
 

--- a/source/blender/io/usd/intern/usd_writer_abstract.cc
+++ b/source/blender/io/usd/intern/usd_writer_abstract.cc
@@ -30,8 +30,11 @@ extern "C" {
 
 #include "BLI_utildefines.h"
 
+#include "DNA_scene_types.h"
+#include "DEG_depsgraph_query.h"
 #include "DNA_modifier_types.h"
 }
+
 
 /* TfToken objects are not cheap to construct, so we do it once. */
 namespace usdtokens {
@@ -138,14 +141,21 @@ pxr::UsdShadeMaterial USDAbstractWriter::ensure_usd_material(Material *material)
                      pxr::UsdShadeMaterial::Define(usd_export_context_.stage, usd_path);
 
   // TODO(bskinner) maybe always export viewport material as variant...
+  const Scene *scene = DEG_get_evaluated_scene(this->usd_export_context_.depsgraph);
   if (material->use_nodes) {
-    create_usd_cycles_material(this->usd_export_context_.stage,
-                               material,
-                               usd_material,
-                               this->usd_export_context_.export_params.export_as_overs);
+    create_usd_cycles_material(this->usd_export_context_.stage, material, usd_material,
+                               this->usd_export_context_.export_params.export_as_overs,
+                               this->usd_export_context_.export_params.export_animated_textures,
+                               this->usd_export_context_.export_params.anim_tex_start,
+                               this->usd_export_context_.export_params.anim_tex_end,
+                               scene->r.cfra);
   }
   if (material->use_nodes && this->usd_export_context_.export_params.generate_preview_surface) {
-    create_usd_preview_surface_material(this->usd_export_context_, material, usd_material);
+    create_usd_preview_surface_material(this->usd_export_context_, material, usd_material,
+                               this->usd_export_context_.export_params.export_animated_textures,
+                               this->usd_export_context_.export_params.anim_tex_start,
+                               this->usd_export_context_.export_params.anim_tex_end,
+                               scene->r.cfra);
   }
   else {
     create_usd_viewport_material(this->usd_export_context_, material, usd_material);

--- a/source/blender/io/usd/intern/usd_writer_material.cc
+++ b/source/blender/io/usd/intern/usd_writer_material.cc
@@ -112,6 +112,7 @@ static const pxr::TfToken attribute("attribute", pxr::TfToken::Immortal);
 static const pxr::TfToken bsdf("bsdf", pxr::TfToken::Immortal);
 static const pxr::TfToken closure("closure", pxr::TfToken::Immortal);
 static const pxr::TfToken vector("vector", pxr::TfToken::Immortal);
+static const pxr::TfToken image_source("image_source", pxr::TfToken::Immortal);
 
 // tokens for animated textures
 static const pxr::TfToken num_frames("num_frames", pxr::TfToken::Immortal);
@@ -291,6 +292,10 @@ bool create_texture_shader_input(pxr::UsdShadeShader &shader,
                                           const double current_frame) {
 
   Image *ima = (Image *) node->id;
+
+  shader.CreateInput(cyclestokens::image_source, pxr::SdfValueTypeNames->Int).Set(
+    static_cast<int>(ima->source));
+
   if (ELEM(ima->source, IMA_SRC_FILE, IMA_SRC_SEQUENCE, IMA_SRC_MOVIE, IMA_SRC_TILED)) {
 
     std::string imagePath = get_node_tex_image_filepath(node);

--- a/source/blender/io/usd/intern/usd_writer_material.cc
+++ b/source/blender/io/usd/intern/usd_writer_material.cc
@@ -1048,6 +1048,19 @@ pxr::UsdShadeShader create_cycles_shader_node(pxr::UsdStageRefPtr a_stage,
                              node_image_tex_alpha_type_conversion,
                              shader,
                              (int)ima->alpha_mode);
+
+      // Colorspace RNA
+      PointerRNA id_ptr;
+      RNA_id_pointer_create(node->id, &id_ptr);
+      BL::Image b_image(id_ptr);
+      PointerRNA colorspace_ptr = b_image.colorspace_settings().ptr;
+      PropertyRNA *prop = RNA_struct_find_property(&colorspace_ptr, "name");
+      const char *identifier = "";
+      int value = RNA_property_enum_get(&colorspace_ptr, prop);
+      RNA_property_enum_identifier(NULL, &colorspace_ptr, prop, value, &identifier);
+
+      shader.CreateInput(cyclestokens::colorspace, pxr::SdfValueTypeNames->String)
+        .Set(std::string(identifier));
     } break;
 
     case SH_NODE_TEX_GRADIENT: {

--- a/source/blender/io/usd/intern/usd_writer_material.h
+++ b/source/blender/io/usd/intern/usd_writer_material.h
@@ -44,15 +44,27 @@ namespace USD {
 
 void create_usd_preview_surface_material(USDExporterContext const &usd_export_context_,
                                          Material *material,
-                                         pxr::UsdShadeMaterial &usd_material);
+                                         pxr::UsdShadeMaterial &usd_material,
+                                         const bool export_animated_textures,
+                                         const double anim_tex_start,
+                                         const double anim_tex_end,
+                                         const double current_frame);
 void create_usd_cycles_material(pxr::UsdStageRefPtr a_stage,
                                 bNodeTree *ntree,
                                 pxr::UsdShadeMaterial &usd_material,
-                                bool a_asOvers);
+                                const bool a_asOvers,
+                                const bool export_animated_textures,
+                                const double anim_tex_start,
+                                const double anim_tex_end,
+                                const double current_frame);
 void create_usd_cycles_material(pxr::UsdStageRefPtr a_stage,
                                 Material *material,
                                 pxr::UsdShadeMaterial &usd_material,
-                                bool a_asOvers);
+                                const bool a_asOvers,
+                                const bool export_animated_textures,
+                                const double anim_tex_start,
+                                const double anim_tex_end,
+                                const double current_frame);
 void create_usd_viewport_material(USDExporterContext const &usd_export_context_,
                                   Material *material,
                                   pxr::UsdShadeMaterial &usd_material);

--- a/source/blender/io/usd/usd.h
+++ b/source/blender/io/usd/usd.h
@@ -65,6 +65,9 @@ struct USDExportParams {
   bool export_normals;
   bool export_transforms;
   bool export_materials;
+  bool export_animated_textures;
+  double anim_tex_start;
+  double anim_tex_end;
   bool export_meshes;
   bool export_lights;
   bool export_cameras;


### PR DESCRIPTION
The following export options are available:
Export Animated Textures - When checked, Image/Environment Textures that are set to an animated Image Sequence are exported, for each frame between the Start and End Frame. If not enabled, the texture for the active scene's current frame is exported as a static texture path.

Start Frame - The start frame to export from.

End Frame - The end frame to export from.

The exported values for each frame match the settings in Blender's Texture nodes as calculated by the Frames, Start Frame, and Offset parameters.  The paths that are exported match the paths that Blender would render from for each frame from the export Start Frame, to the End Frame.