### PR TITLE
Blender USD export -Remove Scope from resulting material network

### DIFF
--- a/source/blender/io/usd/intern/usd_writer_material.cc
+++ b/source/blender/io/usd/intern/usd_writer_material.cc
@@ -1487,6 +1487,8 @@ void create_usd_preview_surface_material(USDExporterContext const &usd_export_co
               created_shader = create_usd_preview_shader_node(
                 usd_export_context_, usd_material, nodeGraph, found_node->name, found_node->type, found_node,
                 export_animated_textures, anim_tex_start, anim_tex_end, current_frame);
+       	      previewSurface.CreateInput(usdtokens::diffuse_color, pxr::SdfValueTypeNames->Float3)
+                .ConnectToSource(created_shader, usdtokens::rgb);
 
             } 
             else {  // Set hardcoded value

--- a/source/blender/io/usd/intern/usd_writer_material.cc
+++ b/source/blender/io/usd/intern/usd_writer_material.cc
@@ -1892,12 +1892,9 @@ void create_usd_cycles_material(pxr::UsdStageRefPtr a_stage,
 
     localize(localtree, localtree);
 
-    usd_define_or_over<pxr::UsdGeomScope>(
-        a_stage, usd_material.GetPath().AppendChild(cyclestokens::cycles), a_asOvers);
-
     store_cycles_nodes(a_stage,
                        localtree,
-                       usd_material.GetPath().AppendChild(cyclestokens::cycles),
+                       usd_material.GetPath(),
                        &output,
                        a_asOvers,
                        export_animated_textures,
@@ -1907,7 +1904,7 @@ void create_usd_cycles_material(pxr::UsdStageRefPtr a_stage,
     link_cycles_nodes(a_stage,
                       usd_material,
                       localtree,
-                      usd_material.GetPath().AppendChild(cyclestokens::cycles),
+                      usd_material.GetPath(),
                       a_asOvers);
 
     ntreeFreeLocalTree(localtree);


### PR DESCRIPTION
Blender usd export currently export material networks with a scope within the material itself.

This causes issues when trying to edit these materials in houdini.

Houdini 'Edit_Materials' is not handling complex material networks or image_texture inputs upon being edited.

Networks with more than one closure fail to rebuild. 
Image_texture nodes fail to find their material path.  They work again when set to 'set or create'

Let the material fully encapsulate the cycles shader without using a scope.