### PR TITLE
New logic for orientation conversion + apply transforms

### DIFF
--- a/source/blender/editors/io/io_usd.c
+++ b/source/blender/editors/io/io_usd.c
@@ -176,6 +176,7 @@ static int wm_usd_export_exec(bContext *C, wmOperator *op)
   const bool generate_preview_surface = RNA_boolean_get(op->ptr, "generate_preview_surface");
   const bool convert_uv_to_st = RNA_boolean_get(op->ptr, "convert_uv_to_st");
   const bool convert_orientation = RNA_boolean_get(op->ptr, "convert_orientation");
+  const bool apply_transforms = RNA_boolean_get(op->ptr, "apply_transforms");
   const bool export_child_particles = RNA_boolean_get(op->ptr, "export_child_particles");
   const bool export_as_overs = RNA_boolean_get(op->ptr, "export_as_overs");
   const bool merge_transform_and_shape = RNA_boolean_get(op->ptr, "merge_transform_and_shape");
@@ -240,6 +241,7 @@ static int wm_usd_export_exec(bContext *C, wmOperator *op)
       convert_orientation,
       global_forward,
       global_up,
+      apply_transforms,
       export_child_particles,
       export_as_overs,
       merge_transform_and_shape,
@@ -367,6 +369,9 @@ static void wm_usd_export_draw(bContext *C, wmOperator *op)
     uiItemR(box, ptr, "export_global_forward_selection", 0, NULL, ICON_NONE);
     uiItemR(box, ptr, "export_global_up_selection", 0, NULL, ICON_NONE);
   }
+
+  if (RNA_boolean_get(ptr, "export_transforms"))
+    uiItemR(box, ptr, "apply_transforms", 0, NULL, ICON_NONE);
 
   if (RNA_boolean_get(ptr, "export_materials"))
     uiItemR(box, ptr, "generate_preview_surface", 0, NULL, ICON_NONE);
@@ -586,6 +591,13 @@ void WM_OT_usd_export(struct wmOperatorType *ot)
                USD_DEFAULT_UP,
                "Up Axis",
                "Global Up axis for export");
+
+  RNA_def_boolean(ot->srna,
+                  "apply_transforms",
+                  false,
+                  "Apply Transforms",
+                  "When checked, the USD exporter will apply any object transforms. "
+                  "This will convert mesh data to world co-ordinates instead of local.");
 
   RNA_def_boolean(ot->srna,
                   "export_child_particles",

--- a/source/blender/io/usd/intern/usd_writer_curve.cc
+++ b/source/blender/io/usd/intern/usd_writer_curve.cc
@@ -54,7 +54,27 @@ void USDCurveWriter::do_write(HierarchyContext &context)
   float mat_transform[4][4];
 
   if (usd_export_context_.export_params.export_transforms &&
-      usd_export_context_.export_params.convert_orientation) {
+      usd_export_context_.export_params.apply_transforms) {
+    // TODO(bjs): This is inefficient checking for every transform. should be moved elsewhere
+    if (usd_export_context_.export_params.convert_orientation) {
+      float mrot[3][3];
+      float mat[4][4];
+      mat3_from_axis_conversion(USD_GLOBAL_FORWARD_Y,
+                                +USD_GLOBAL_UP_Z,
+                                +usd_export_context_.export_params.forward_axis,
+                                +usd_export_context_.export_params.up_axis,
+                                +mrot);
+      transpose_m3(mrot);
+      copy_m4_m3(mat, mrot);
+      mul_m4_m4m4(mat_transform, mat, context.matrix_world);
+    }
+    else {
+      copy_m4_m4(mat_transform, context.matrix_world);
+    }
+    BKE_curve_transform(curve, mat_transform, true, true);
+  }
+  else if (usd_export_context_.export_params.export_transforms &&
+           usd_export_context_.export_params.convert_orientation) {
     float mrot[3][3];
     mat3_from_axis_conversion(USD_GLOBAL_FORWARD_Y,
                               USD_GLOBAL_UP_Z,
@@ -224,7 +244,9 @@ void USDCurveWriter::do_write(HierarchyContext &context)
     write_id_properties(prim, curve->id, timecode);
   }
 
-  if (usd_export_context_.export_params.export_transforms) {
+  if (usd_export_context_.export_params.export_transforms &&
+      (usd_export_context_.export_params.apply_transforms ||
+       usd_export_context_.export_params.convert_orientation)) {
     invert_m4(mat_transform);
     BKE_curve_transform(curve, mat_transform, true, true);
   }

--- a/source/blender/io/usd/intern/usd_writer_curve.cc
+++ b/source/blender/io/usd/intern/usd_writer_curve.cc
@@ -51,28 +51,19 @@ void USDCurveWriter::do_write(HierarchyContext &context)
 
   Curve *curve = static_cast<Curve *>(context.object->data);
 
-  float matrix_world[4][4];
+  float mat_transform[4][4];
 
-  if (usd_export_context_.export_params.export_transforms) {
-    // TODO(bjs): This is inefficient checking for every transform. should be moved elsewhere
-    if (usd_export_context_.export_params.convert_orientation) {
-      float mrot[3][3];
-      float mat[4][4];
-      mat3_from_axis_conversion(USD_GLOBAL_FORWARD_Y,
-                                USD_GLOBAL_UP_Z,
-                                usd_export_context_.export_params.forward_axis,
-                                usd_export_context_.export_params.up_axis,
-                                mrot);
-      transpose_m3(mrot);
-      copy_m4_m3(mat, mrot);
-      mul_m4_m4m4(matrix_world, mat, context.matrix_world);
-    }
-    else
-    {
-      copy_m4_m4(matrix_world, context.matrix_world);
-    }
-
-    BKE_curve_transform(curve, matrix_world, true, true);
+  if (usd_export_context_.export_params.export_transforms &&
+      usd_export_context_.export_params.convert_orientation) {
+    float mrot[3][3];
+    mat3_from_axis_conversion(USD_GLOBAL_FORWARD_Y,
+                              USD_GLOBAL_UP_Z,
+                              usd_export_context_.export_params.forward_axis,
+                              usd_export_context_.export_params.up_axis,
+                              mrot);
+    transpose_m3(mrot);
+    copy_m4_m3(mat_transform, mrot);
+    BKE_curve_transform(curve, mat_transform, true, true);
   }
 
   pxr::VtArray<pxr::GfVec3f> verts;
@@ -234,8 +225,8 @@ void USDCurveWriter::do_write(HierarchyContext &context)
   }
 
   if (usd_export_context_.export_params.export_transforms) {
-    invert_m4(matrix_world);
-    BKE_curve_transform(curve, matrix_world, true, true);
+    invert_m4(mat_transform);
+    BKE_curve_transform(curve, mat_transform, true, true);
   }
 }
 

--- a/source/blender/io/usd/intern/usd_writer_mesh.cc
+++ b/source/blender/io/usd/intern/usd_writer_mesh.cc
@@ -348,8 +348,7 @@ void USDGenericMeshWriter::write_vertex_groups(const Object *ob,
           /* This out of bounds check is necessary because MDeformVert.totweight can be
           larger than the number of bDeformGroup structs in Object.defbase. It appears to be
           a Blender bug that can cause this scenario.*/
-          if (idx < num_groups)
-          {
+          if (idx < num_groups) {
             pv_data[idx][i] = w;
           }
         }
@@ -378,8 +377,7 @@ void USDGenericMeshWriter::write_vertex_groups(const Object *ob,
             /* This out of bounds check is necessary because MDeformVert.totweight can be
             larger than the number of bDeformGroup structs in Object.defbase. Appears to be
             a Blender bug that can cause this scenario.*/
-            if (idx < num_groups)
-            {
+            if (idx < num_groups) {
               pv_data[idx][p_idx] = w;
             }
           }
@@ -464,28 +462,19 @@ void USDGenericMeshWriter::write_mesh(HierarchyContext &context, Mesh *mesh)
           pxr::UsdGeomMesh::Define(usd_export_context_.stage, usd_export_context_.usd_path);
   USDMeshData usd_mesh_data;
 
-  float matrix_world[4][4];
+  float mat_transform[4][4];
 
-  if (usd_export_context_.export_params.export_transforms) {
-    // TODO(bjs): This is inefficient checking for every transform. should be moved elsewhere
-    if (usd_export_context_.export_params.convert_orientation) {
-      float mrot[3][3];
-      float mat[4][4];
-      mat3_from_axis_conversion(USD_GLOBAL_FORWARD_Y,
-                                USD_GLOBAL_UP_Z,
-                                usd_export_context_.export_params.forward_axis,
-                                usd_export_context_.export_params.up_axis,
-                                mrot);
-      transpose_m3(mrot);
-      copy_m4_m3(mat, mrot);
-      mul_m4_m4m4(matrix_world, mat, context.matrix_world);
-    }
-    else
-    {
-      copy_m4_m4(matrix_world, context.matrix_world);
-    }
-
-    BKE_mesh_transform(mesh, matrix_world, true);
+  if (usd_export_context_.export_params.export_transforms &&
+      usd_export_context_.export_params.convert_orientation) {
+    float mrot[3][3];
+    mat3_from_axis_conversion(USD_GLOBAL_FORWARD_Y,
+                              USD_GLOBAL_UP_Z,
+                              usd_export_context_.export_params.forward_axis,
+                              usd_export_context_.export_params.up_axis,
+                              mrot);
+    transpose_m3(mrot);
+    copy_m4_m3(mat_transform, mrot);
+    BKE_mesh_transform(mesh, mat_transform, true);
     BKE_mesh_calc_normals(mesh);
   }
 
@@ -582,9 +571,10 @@ void USDGenericMeshWriter::write_mesh(HierarchyContext &context, Mesh *mesh)
     assign_materials(context, usd_mesh, usd_mesh_data.face_groups);
   }
 
-  if (usd_export_context_.export_params.export_transforms) {
-    invert_m4(matrix_world);
-    BKE_mesh_transform(mesh, matrix_world, true);
+  if (usd_export_context_.export_params.export_transforms &&
+      usd_export_context_.export_params.convert_orientation) {
+    invert_m4(mat_transform);
+    BKE_mesh_transform(mesh, mat_transform, true);
     BKE_mesh_calc_normals(mesh);
   }
 }

--- a/source/blender/io/usd/intern/usd_writer_mesh.cc
+++ b/source/blender/io/usd/intern/usd_writer_mesh.cc
@@ -463,6 +463,32 @@ void USDGenericMeshWriter::write_mesh(HierarchyContext &context, Mesh *mesh)
           pxr::UsdGeomMesh(usd_export_context_.stage->OverridePrim(usd_export_context_.usd_path)) :
           pxr::UsdGeomMesh::Define(usd_export_context_.stage, usd_export_context_.usd_path);
   USDMeshData usd_mesh_data;
+
+  float matrix_world[4][4];
+
+  if (usd_export_context_.export_params.export_transforms) {
+    // TODO(bjs): This is inefficient checking for every transform. should be moved elsewhere
+    if (usd_export_context_.export_params.convert_orientation) {
+      float mrot[3][3];
+      float mat[4][4];
+      mat3_from_axis_conversion(USD_GLOBAL_FORWARD_Y,
+                                USD_GLOBAL_UP_Z,
+                                usd_export_context_.export_params.forward_axis,
+                                usd_export_context_.export_params.up_axis,
+                                mrot);
+      transpose_m3(mrot);
+      copy_m4_m3(mat, mrot);
+      mul_m4_m4m4(matrix_world, mat, context.matrix_world);
+    }
+    else
+    {
+      copy_m4_m4(matrix_world, context.matrix_world);
+    }
+
+    BKE_mesh_transform(mesh, matrix_world, true);
+    BKE_mesh_calc_normals(mesh);
+  }
+
   get_geometry_data(mesh, usd_mesh_data);
 
   if (usd_export_context_.export_params.use_instancing && context.is_instance()) {
@@ -554,6 +580,12 @@ void USDGenericMeshWriter::write_mesh(HierarchyContext &context, Mesh *mesh)
 
   if (usd_export_context_.export_params.export_materials) {
     assign_materials(context, usd_mesh, usd_mesh_data.face_groups);
+  }
+
+  if (usd_export_context_.export_params.export_transforms) {
+    invert_m4(matrix_world);
+    BKE_mesh_transform(mesh, matrix_world, true);
+    BKE_mesh_calc_normals(mesh);
   }
 }
 

--- a/source/blender/io/usd/intern/usd_writer_transform.cc
+++ b/source/blender/io/usd/intern/usd_writer_transform.cc
@@ -66,14 +66,13 @@ void USDTransformWriter::do_write(HierarchyContext &context)
     }
   }
 
-  if (usd_export_context_.export_params.export_transforms) {
+  if (false && usd_export_context_.export_params.export_transforms) {
     float parent_relative_matrix[4][4];  // The object matrix relative to the parent.
 
     // TODO(bjs): This is inefficient checking for every transform. should be moved elsewhere
     if (context.export_parent == nullptr &&
         usd_export_context_.export_params.convert_orientation) {
       float matrix_world[4][4];
-      copy_m4_m4(matrix_world, context.matrix_world);
       float mrot[3][3];
       float mat[4][4];
       mat3_from_axis_conversion(USD_GLOBAL_FORWARD_Y,

--- a/source/blender/io/usd/intern/usd_writer_transform.cc
+++ b/source/blender/io/usd/intern/usd_writer_transform.cc
@@ -97,7 +97,8 @@ void USDTransformWriter::do_write(HierarchyContext &context)
     }
   }
 
-  if (usd_export_context_.export_params.export_transforms) {
+  if (usd_export_context_.export_params.export_transforms &&
+      !usd_export_context_.export_params.apply_transforms) {
     float parent_relative_matrix[4][4];
     // The object matrix relative to the parent.
     if (usd_export_context_.export_params.convert_orientation) {

--- a/source/blender/io/usd/intern/usd_writer_transform.cc
+++ b/source/blender/io/usd/intern/usd_writer_transform.cc
@@ -27,6 +27,7 @@ extern "C" {
 
 #include "BLI_math_matrix.h"
 #include "BLI_math_rotation.h"
+#include "BLI_math_vector.h"
 
 #include "DNA_layer_types.h"
 }
@@ -42,6 +43,126 @@ static const float UNIT_M4[4][4] = {
 
 USDTransformWriter::USDTransformWriter(const USDExporterContext &ctx) : USDAbstractWriter(ctx)
 {
+}
+
+void mat4_to_loc_eul_size(float loc[3], float eul[3], float size[3], const float (*M)[4])
+{
+  float rot[3][3];
+
+  mat4_to_loc_rot_size(loc, rot, size, M);
+  mat3_to_eul(eul, rot);
+}
+
+BLI_INLINE int _axis_signed(const int axis)
+{
+  return (axis < 3) ? axis : axis - 3;
+}
+
+void swap_axes(int src, int dst, float loc[3], float eul[3], float size[3])
+{
+  float sign = (src > 3) != (dst > 3) ? -1.0 : 1.0;
+
+  int asrc = _axis_signed(src);
+  int adst = _axis_signed(dst);
+
+  float tmp = loc[asrc];
+  loc[asrc] = sign * loc[adst];
+  loc[adst] = sign * tmp;
+
+  tmp = eul[asrc];
+  eul[asrc] = sign * eul[adst];
+  eul[adst] = sign * tmp;
+
+  tmp = size[asrc];
+  size[asrc] = size[adst];
+  size[adst] = tmp;
+}
+
+void convert_axes(int src_forward,
+                  int src_up,
+                  int dst_forward,
+                  int dst_up,
+                  float loc[3],
+                  float eul[3],
+                  float size[3])
+{
+  if (src_forward == dst_forward && src_up == dst_up) {
+    return;
+  }
+
+  if ((_axis_signed(src_forward) == _axis_signed(src_up)) ||
+      (_axis_signed(dst_forward) == _axis_signed(dst_up))) {
+    return;
+  }
+
+  swap_axes(src_up, dst_up, loc, eul, size);
+  swap_axes(src_forward, dst_forward, loc, eul, size);
+}
+
+void convert_axes(int src_forward, int src_up, int dst_forward, int dst_up, float mat[4][4])
+{
+  float loc[3], eul[3], size[3];
+  mat4_to_loc_eul_size(loc, eul, size, mat);
+  float mattest[4][4];
+  loc_eul_size_to_mat4(mattest, loc, eul, size);
+  float mrot[3][3];
+  mat3_from_axis_conversion(src_forward, src_up, dst_forward, dst_up, mrot);
+  transpose_m3(mrot);
+  mul_m3_v3(mrot, loc);
+  mul_m3_v3(mrot, eul);
+  for (int x = 0; x < 3; x++) {
+    for (int y = 0; y < 3; y++) {
+      if (mrot[x][y] < 0.0f) {
+        mrot[x][y] *= -1.0f;
+      }
+    }
+  }
+  mul_m3_v3(mrot, size);
+  loc_eul_size_to_mat4(mat, loc, eul, size);
+}
+
+void build_converted_matrix_world(const int &src_forward,
+                                  const int &src_up,
+                                  const int &dst_forward,
+                                  const int &dst_up,
+                                  Object *ob,
+                                  float mat[4][4])
+{
+  if (!ob) {
+    int i, j;
+    for (i = 0; i < 4; i++) {
+      for (j = 0; j < 4; j++) {
+        mat[i][j] = 0.0f;
+      }
+    }
+    for (i = 0; i < 4; i++) {
+      mat[i][i] = 1.0f;
+    }
+  }
+  else {
+    float mrot[3][3];
+    mat3_from_axis_conversion(src_forward, src_up, dst_forward, dst_up, mrot);
+    transpose_m3(mrot);
+
+    float loc[3], eul[3], size[3];
+    copy_v3_v3(loc, ob->loc);
+    copy_v3_v3(eul, ob->rot);
+    copy_v3_v3(size, ob->scale);
+
+    mul_m3_v3(mrot, loc);
+    mul_m3_v3(mrot, eul);
+
+    for (int i = 0; i < 4; i++) {
+      for (int j = 0; j < 4; j++) {
+        if (mrot[i][j] < 0.0f) {
+          mrot[i][j] *= -1.0f;
+        }
+      }
+    }
+
+    mul_m3_v3(mrot, size);
+    loc_eul_size_to_mat4(mat, loc, eul, size);
+  }
 }
 
 void USDTransformWriter::do_write(HierarchyContext &context)
@@ -66,27 +187,27 @@ void USDTransformWriter::do_write(HierarchyContext &context)
     }
   }
 
-  if (false && usd_export_context_.export_params.export_transforms) {
-    float parent_relative_matrix[4][4];  // The object matrix relative to the parent.
-
-    // TODO(bjs): This is inefficient checking for every transform. should be moved elsewhere
-    if (context.export_parent == nullptr &&
-        usd_export_context_.export_params.convert_orientation) {
-      float matrix_world[4][4];
-      float mrot[3][3];
-      float mat[4][4];
-      mat3_from_axis_conversion(USD_GLOBAL_FORWARD_Y,
-                                USD_GLOBAL_UP_Z,
-                                usd_export_context_.export_params.forward_axis,
-                                usd_export_context_.export_params.up_axis,
-                                mrot);
-      transpose_m3(mrot);
-      copy_m4_m3(mat, mrot);
-      mul_m4_m4m4(matrix_world, mat, context.matrix_world);
-      mul_m4_m4m4(parent_relative_matrix, context.parent_matrix_inv_world, matrix_world);
+  if (usd_export_context_.export_params.export_transforms) {
+    float parent_relative_matrix[4][4];
+    // The object matrix relative to the parent.
+    if (usd_export_context_.export_params.convert_orientation) {
+      float parent_inv_world[4][4], matrix_world[4][4];
+      copy_m4_m4(matrix_world, context.matrix_world);
+      copy_m4_m4(parent_inv_world, context.parent_matrix_inv_world);
+      invert_m4(parent_inv_world);
+      convert_axes(USD_GLOBAL_FORWARD_Y,
+                   USD_GLOBAL_UP_Z,
+                   usd_export_context_.export_params.forward_axis,
+                   usd_export_context_.export_params.up_axis,
+                   parent_inv_world);
+      invert_m4(parent_inv_world);
+      convert_axes(USD_GLOBAL_FORWARD_Y,
+                   USD_GLOBAL_UP_Z,
+                   usd_export_context_.export_params.forward_axis,
+                   usd_export_context_.export_params.up_axis,
+                   matrix_world);
+      mul_m4_m4m4(parent_relative_matrix, parent_inv_world, matrix_world);
     }
-    else
-      mul_m4_m4m4(parent_relative_matrix, context.parent_matrix_inv_world, context.matrix_world);
 
     // USD Xforms are by default set with an identity transform.
     // This check ensures transforms of non-identity are authored
@@ -96,6 +217,7 @@ void USDTransformWriter::do_write(HierarchyContext &context)
       if (!xformOp_) {
         xformOp_ = xform.AddTransformOp();
       }
+
       xformOp_.Set(pxr::GfMatrix4d(parent_relative_matrix), get_export_time_code());
     }
   }

--- a/source/blender/io/usd/usd.h
+++ b/source/blender/io/usd/usd.h
@@ -85,6 +85,7 @@ struct USDExportParams {
   bool convert_orientation;
   enum USD_global_forward_axis forward_axis;
   enum USD_global_up_axis up_axis;
+  bool apply_transforms;
   bool export_child_particles;
   bool export_as_overs;
   bool merge_transform_and_shape;


### PR DESCRIPTION
Added logic to bake/apply all transforms to a mesh/curve, as well as to bake/apply the axis conversion to the mesh/curve when the convert orientation option is selected. The logic for the transforms has also been updated to reflect this change. The advantage of this approach is that no new transforms are being added to the USD hierarchy, only existing transforms are modified.