### PR TITLE
When exporting lights, CreateNormalizeAttr() and set it to true.

### DIFF
--- a/source/blender/io/usd/intern/usd_writer_light.cc
+++ b/source/blender/io/usd/intern/usd_writer_light.cc
@@ -151,6 +151,7 @@ void USDLightWriter::do_write(HierarchyContext &context)
 
   usd_light.CreateColorAttr().Set(pxr::GfVec3f(light->r, light->g, light->b), timecode);
   usd_light.CreateSpecularAttr().Set(light->spec_fac, timecode);
+  usd_light.CreateNormalizeAttr().Set(pxr::VtValue(true), timecode);
 
   if (usd_export_context_.export_params.export_custom_properties && light) {
     auto prim = usd_light.GetPrim();


### PR DESCRIPTION
This is so that exported lights from Blender will match when rendered externally with hdBlackbird, with no edits.  

A normalize toggle was added to hdBlackbird:
https://github.com/tangent-opensource/hdBlackbird/pull/144

However, since they are normalized in Blender/Cycles, the resulting render with no edits to the lights in hdBlackbird will mismatch without exporting the normalize attribute.